### PR TITLE
Fix 'undefined variable' warnings

### DIFF
--- a/Report_Tool/report.pl
+++ b/Report_Tool/report.pl
@@ -13925,7 +13925,8 @@ sub sanity_node
     # parameter sanity checks
     if ($parameter) {
         # keep track of used types for output
-        $used_data_type_list->{$node->{'type'} eq 'dataType' ?  $node->{'syntax'}->{'ref'} : $node->{'type'}} = 1;
+        my $typeinfo = get_typeinfo($type, $syntax);
+        $used_data_type_list->{$typeinfo->{value}} = 1;
 
         # XXX this isn't always an error; depends on whether table entries
         #     correspond to device configuration


### PR DESCRIPTION
Used the get_typeinfo() function, which handles the various cases (one of which wasn't covered by the existing code).